### PR TITLE
chore: get rid of downloading log

### DIFF
--- a/download.ts
+++ b/download.ts
@@ -21,7 +21,6 @@ export async function download(binary: string, version: string): Promise<string>
     }
   }
   const key = `${binary}/${version}/${Deno.build.target}`
-  console.error("Downloading", key)
   const response = await fetch(
     new URL(key, capiBinariesApi),
   )


### PR DESCRIPTION
Given that this lib is likely to be consumed in other tools (such as Capi), let's not bake in the downloading log.