### PR TITLE
fix: disable `stout-collator` binary again

### DIFF
--- a/.github/workflows/check_all.yml
+++ b/.github/workflows/check_all.yml
@@ -28,11 +28,11 @@ jobs:
             repo: paritytech/trappist
             args: --features with-trappist-runtime
             type: commit
-          - name: stout-collator
-            repo: paritytech/trappist
-            args: --no-default-features --features with-stout-runtime
-            from: trappist-collator
-            type: commit
+          # - name: stout-collator
+          #   repo: paritytech/trappist
+          #   args: --no-default-features --features with-stout-runtime
+          #   from: trappist-collator
+          #   type: commit
         target:
           - triple: x86_64-unknown-linux-gnu
             runner: ubuntu-20.04


### PR DESCRIPTION
Reverts paritytech/capi-binary-builds#39