### PR TITLE
fix: polkadot/polkadot-parachain binary patches

### DIFF
--- a/patches/polkadot-fast.patch
+++ b/patches/polkadot-fast.patch
@@ -1,5 +1,5 @@
 diff --git a/runtime/kusama/constants/src/lib.rs b/runtime/kusama/constants/src/lib.rs
-index 73ca3d31652..72456cad409 100644
+index 73ca3d31652..02674492460 100644
 --- a/runtime/kusama/constants/src/lib.rs
 +++ b/runtime/kusama/constants/src/lib.rs
 @@ -40,7 +40,7 @@ pub mod currency {
@@ -7,12 +7,12 @@ index 73ca3d31652..72456cad409 100644
  	use primitives::{BlockNumber, Moment};
  	use runtime_common::prod_or_fast;
 -	pub const MILLISECS_PER_BLOCK: Moment = 6000;
-+	pub const MILLISECS_PER_BLOCK: Moment = 2000;
++	pub const MILLISECS_PER_BLOCK: Moment = 4000;
  	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
  	pub const EPOCH_DURATION_IN_SLOTS: BlockNumber = prod_or_fast!(1 * HOURS, 1 * MINUTES);
  
 diff --git a/runtime/polkadot/constants/src/lib.rs b/runtime/polkadot/constants/src/lib.rs
-index 68b2fdcd306..d2f0b9ca806 100644
+index 68b2fdcd306..91014fb8178 100644
 --- a/runtime/polkadot/constants/src/lib.rs
 +++ b/runtime/polkadot/constants/src/lib.rs
 @@ -41,7 +41,7 @@ pub mod currency {
@@ -20,12 +20,12 @@ index 68b2fdcd306..d2f0b9ca806 100644
  	use primitives::{BlockNumber, Moment};
  	use runtime_common::prod_or_fast;
 -	pub const MILLISECS_PER_BLOCK: Moment = 6000;
-+	pub const MILLISECS_PER_BLOCK: Moment = 2000;
++	pub const MILLISECS_PER_BLOCK: Moment = 4000;
  	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
  	pub const EPOCH_DURATION_IN_SLOTS: BlockNumber = prod_or_fast!(4 * HOURS, 1 * MINUTES);
  
 diff --git a/runtime/rococo/constants/src/lib.rs b/runtime/rococo/constants/src/lib.rs
-index 0683bc377e1..17f3fc8e77b 100644
+index 0683bc377e1..9fa1b8567a4 100644
 --- a/runtime/rococo/constants/src/lib.rs
 +++ b/runtime/rococo/constants/src/lib.rs
 @@ -39,7 +39,7 @@ pub mod currency {
@@ -33,12 +33,12 @@ index 0683bc377e1..17f3fc8e77b 100644
  	use primitives::{BlockNumber, Moment};
  	use runtime_common::prod_or_fast;
 -	pub const MILLISECS_PER_BLOCK: Moment = 6000;
-+	pub const MILLISECS_PER_BLOCK: Moment = 2000;
++	pub const MILLISECS_PER_BLOCK: Moment = 4000;
  	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
  	pub const DEFAULT_EPOCH_DURATION: BlockNumber = prod_or_fast!(1 * HOURS, 1 * MINUTES);
  	frame_support::parameter_types! {
 diff --git a/runtime/test-runtime/constants/src/lib.rs b/runtime/test-runtime/constants/src/lib.rs
-index ca329accec8..08eabe154f4 100644
+index ca329accec8..b95352e5ae4 100644
 --- a/runtime/test-runtime/constants/src/lib.rs
 +++ b/runtime/test-runtime/constants/src/lib.rs
 @@ -32,7 +32,7 @@ pub mod currency {
@@ -46,12 +46,12 @@ index ca329accec8..08eabe154f4 100644
  	use primitives::{BlockNumber, Moment};
  	// Testnet
 -	pub const MILLISECS_PER_BLOCK: Moment = 6000;
-+	pub const MILLISECS_PER_BLOCK: Moment = 2000;
++	pub const MILLISECS_PER_BLOCK: Moment = 4000;
  	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
  	// 30 seconds for now
  	pub const EPOCH_DURATION_IN_SLOTS: BlockNumber = MINUTES / 2;
 diff --git a/runtime/westend/constants/src/lib.rs b/runtime/westend/constants/src/lib.rs
-index e7d1a627713..86ef81367b8 100644
+index e7d1a627713..7e49f34c2f0 100644
 --- a/runtime/westend/constants/src/lib.rs
 +++ b/runtime/westend/constants/src/lib.rs
 @@ -40,7 +40,7 @@ pub mod time {
@@ -59,7 +59,7 @@ index e7d1a627713..86ef81367b8 100644
  	use runtime_common::prod_or_fast;
  
 -	pub const MILLISECS_PER_BLOCK: Moment = 6000;
-+	pub const MILLISECS_PER_BLOCK: Moment = 2000;
++	pub const MILLISECS_PER_BLOCK: Moment = 4000;
  	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
  	pub const EPOCH_DURATION_IN_SLOTS: BlockNumber = prod_or_fast!(1 * HOURS, 1 * MINUTES);
  

--- a/patches/polkadot-parachain-fast.patch
+++ b/patches/polkadot-parachain-fast.patch
@@ -1,5 +1,5 @@
 diff --git a/parachain-template/runtime/src/lib.rs b/parachain-template/runtime/src/lib.rs
-index 7b5d0b4e2..c2717e933 100644
+index 7b5d0b4e2..d81f7bc25 100644
 --- a/parachain-template/runtime/src/lib.rs
 +++ b/parachain-template/runtime/src/lib.rs
 @@ -189,7 +189,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
@@ -7,12 +7,12 @@ index 7b5d0b4e2..c2717e933 100644
  ///
  /// Change this to adjust the block time.
 -pub const MILLISECS_PER_BLOCK: u64 = 12000;
-+pub const MILLISECS_PER_BLOCK: u64 = 4000;
++pub const MILLISECS_PER_BLOCK: u64 = 8000;
  
  // NOTE: Currently it is not possible to change the slot duration after the chain has started.
  //       Attempting to do so will brick block production.
 diff --git a/parachains/common/src/lib.rs b/parachains/common/src/lib.rs
-index 8ac464ea0..a0e7832da 100644
+index 8ac464ea0..357f5176b 100644
 --- a/parachains/common/src/lib.rs
 +++ b/parachains/common/src/lib.rs
 @@ -76,7 +76,7 @@ mod constants {
@@ -20,12 +20,12 @@ index 8ac464ea0..a0e7832da 100644
  	///
  	/// Change this to adjust the block time.
 -	pub const MILLISECS_PER_BLOCK: u64 = 12000;
-+	pub const MILLISECS_PER_BLOCK: u64 = 4000;
++	pub const MILLISECS_PER_BLOCK: u64 = 8000;
  	pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
  
  	// Time is measured by number of blocks.
 diff --git a/parachains/runtimes/testing/penpal/src/lib.rs b/parachains/runtimes/testing/penpal/src/lib.rs
-index c6c6987fb..deeb80cd9 100644
+index c6c6987fb..bb53a1665 100644
 --- a/parachains/runtimes/testing/penpal/src/lib.rs
 +++ b/parachains/runtimes/testing/penpal/src/lib.rs
 @@ -206,7 +206,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
@@ -33,12 +33,12 @@ index c6c6987fb..deeb80cd9 100644
  ///
  /// Change this to adjust the block time.
 -pub const MILLISECS_PER_BLOCK: u64 = 12000;
-+pub const MILLISECS_PER_BLOCK: u64 = 4000;
++pub const MILLISECS_PER_BLOCK: u64 = 8000;
  
  // NOTE: Currently it is not possible to change the slot duration after the chain has started.
  //       Attempting to do so will brick block production.
 diff --git a/parachains/runtimes/testing/rococo-parachain/src/lib.rs b/parachains/runtimes/testing/rococo-parachain/src/lib.rs
-index 0b6927fa3..e67ac73d7 100644
+index 0b6927fa3..40786f65e 100644
 --- a/parachains/runtimes/testing/rococo-parachain/src/lib.rs
 +++ b/parachains/runtimes/testing/rococo-parachain/src/lib.rs
 @@ -108,7 +108,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
@@ -46,12 +46,12 @@ index 0b6927fa3..e67ac73d7 100644
  };
  
 -pub const MILLISECS_PER_BLOCK: u64 = 12000;
-+pub const MILLISECS_PER_BLOCK: u64 = 4000;
++pub const MILLISECS_PER_BLOCK: u64 = 8000;
  
  pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
  
 diff --git a/test/runtime/src/lib.rs b/test/runtime/src/lib.rs
-index 6ee6afd46..3f22ac240 100644
+index 6ee6afd46..e11e59752 100644
 --- a/test/runtime/src/lib.rs
 +++ b/test/runtime/src/lib.rs
 @@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
@@ -59,7 +59,7 @@ index 6ee6afd46..3f22ac240 100644
  };
  
 -pub const MILLISECS_PER_BLOCK: u64 = 12000;
-+pub const MILLISECS_PER_BLOCK: u64 = 4000;
++pub const MILLISECS_PER_BLOCK: u64 = 8000;
  
  pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
  


### PR DESCRIPTION
Closes https://github.com/paritytech/capi/issues/1020

Fix polkadot v0.9.41+ binaries.

Since polkadot v0.9.41 the block time needs to be at least 4 seconds